### PR TITLE
Hotfix: CVE-2024-35195

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,5 +7,5 @@ python-jose[cryptography]
 httpx
 python-dotenv
 passlib[bcrypt]
-requests
+requests>=2.32.2
 groq


### PR DESCRIPTION
Forced requests package to be in a version newer than or on 2.32.2 (CVE patched in 2.32.2)
