### PR TITLE
Uses timezone aware datetime for user creation

### DIFF
--- a/app/routers/auth_router.py
+++ b/app/routers/auth_router.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from fastapi import APIRouter, Body, Depends, HTTPException, status
 from fastapi.security import OAuth2PasswordRequestForm
 from typing import Dict
@@ -56,7 +56,7 @@ async def register(
         "username": user.username,
         "email": user.email,
         "password_hash": hashed_password,
-        "created_at": datetime.now(tz=datetime.timezone.utc),
+        "created_at": datetime.now(tz=timezone.utc),
         "last_login": None,
         "is_active": True
     }


### PR DESCRIPTION
Ensures that user creation timestamps are timezone-aware by
using `datetime.timezone.utc` instead of `datetime.utc`.
This improves consistency and avoids potential issues related
to time zone handling.
